### PR TITLE
Feat: Add the possibility to specify jwt content

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ import { defineConfig } from '@adonisjs/auth'
 import { InferAuthEvents, Authenticators } from '@adonisjs/auth/types'
 import { sessionGuard, sessionUserProvider } from '@adonisjs/auth/session'
 import { jwtGuard } from '@maximemrf/adonisjs-jwt/jwt_config'
+import { JwtGuardUser } from '@maximemrf/adonisjs-jwt/types'
 
 const authConfig = defineConfig({
   // define the default authenticator to jwt
@@ -45,6 +46,11 @@ const authConfig = defineConfig({
       useCookies: true,
       provider: sessionUserProvider({
         model: () => import('#models/user'),
+      }),
+      // content is a function that takes the user and returns the content of the token, it can be optional, by default it returns only the user id
+      content: (user: JwtGuardUser<User>) => ({
+        id: user.getId(),
+        email: user.getOriginal().email,
       }),
     }),
   },

--- a/src/define_config.ts
+++ b/src/define_config.ts
@@ -1,12 +1,13 @@
 import { GuardConfigProvider } from '@adonisjs/auth/types'
 import type { HttpContext } from '@adonisjs/core/http'
-import { JwtGuard, JwtUserProviderContract } from './jwt.js'
+import { JwtGuard, JwtGuardUser, JwtUserProviderContract } from './jwt.js'
 import { Secret } from '@adonisjs/core/helpers'
 
 export function jwtGuard<UserProvider extends JwtUserProviderContract<unknown>>(config: {
   provider: UserProvider
   tokenExpiresIn?: number | string
   useCookies?: boolean
+  content: <T>(user: JwtGuardUser<T>) => Record<string, any>
 }): GuardConfigProvider<(ctx: HttpContext) => JwtGuard<UserProvider>> {
   return {
     async resolver(_, app) {
@@ -15,6 +16,7 @@ export function jwtGuard<UserProvider extends JwtUserProviderContract<unknown>>(
         secret: appKey,
         expiresIn: config.tokenExpiresIn,
         useCookies: config.useCookies,
+        content: config.content,
       }
       return (ctx) => new JwtGuard(ctx, config.provider, options)
     },

--- a/tests/guard.spec.ts
+++ b/tests/guard.spec.ts
@@ -1,8 +1,8 @@
 import { test } from '@japa/runner'
-import { JwtGuard } from '../src/jwt.js'
+import { JwtGuard, JwtGuardUser } from '../src/jwt.js'
 import { HttpContextFactory } from '@adonisjs/core/factories/http'
 import { errors } from '@adonisjs/auth'
-import { JwtFakeUserProvider } from '../factories/main.js'
+import { JwtAuthFakeUser, JwtFakeUserProvider } from '../factories/main.js'
 import jwt from 'jsonwebtoken'
 import { timeTravel } from '../tests/helpers.js'
 
@@ -37,6 +37,36 @@ test.group('Jwt guard | authenticate', () => {
 
     assert.equal(guard.user, authenticatedUser)
     assert.deepEqual(guard.getUserOrFail(), authenticatedUser)
+  })
+
+  test('it should return the content function provided when generating jwt', async ({ assert }) => {
+    const ctx = new HttpContextFactory().create()
+    const userProvider = new JwtFakeUserProvider()
+    const jwtContentFn = (user: JwtGuardUser<JwtAuthFakeUser>) => ({
+      id: user.getId(),
+      otherProperty: 'random',
+    })
+    const guard = new JwtGuard(ctx, userProvider, {
+      secret: 'thisisasecret',
+      expiresIn: '1h',
+      content: jwtContentFn,
+      useCookies: false,
+    })
+    const user = await userProvider.findById(1)
+
+    const content = jwtContentFn(user!)
+    const tokenResponse: any = await guard.generate(user!.getOriginal())
+    let decoded: any = {}
+
+    if ('token' in tokenResponse) decoded = jwt.verify(tokenResponse.token, 'thisisasecret')
+    else assert.fail('Token response is not an object when useCookies is false')
+
+    assert.equal(tokenResponse.type, 'bearer')
+    assert.exists(tokenResponse.token)
+    assert.equal(tokenResponse.expiresIn, '1h')
+
+    assert.equal(decoded.id, content.id)
+    assert.equal(decoded.otherProperty, content.otherProperty)
   })
 
   test('throw error when cookie header is invalid', async ({ assert }) => {


### PR DESCRIPTION
**Overview**
This pull request includes an improvement to the AdonisJS JWT authentication package.

**Configuration Enhancements:**

Added a new content option to the jwtGuard configuration in src/define_config.ts to allow custom JWT content.

**JWT Guard Enhancements:**

Introduced a content function in JwtGuardOptions to customize the JWT payload.
Updated JwtGuard to utilize the content function during token generation.

**Added tests:**

Added a new test case in tests/guard.spec.ts to verify the custom JWT content functionality.

This pull request aims to enhance the flexibility and functionality of the AdonisJS JWT package, providing more options for customization and better alignment with user needs.