### PR TITLE
feat: possibility of adding a name and passing abilities to the new refresh token

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,9 @@ const refreshToken = await User.refreshTokens.create(user)
 // if you use the refresh token
 router.post('jwt/refresh', async ({ auth }) => {
   // this will authenticate the user using the refresh token
-  // it will delete the old refresh token and generate a new one
-  const user = await auth.use('jwt').authenticateWithRefreshToken()
+  // it will delete the old refresh token and generate a new one with the same abilities
+  // You could pass a name for the new token as well
+  const user = await auth.use('jwt').authenticateWithRefreshToken('optional_name')
   const newRefreshToken = user.currentToken
   const newToken = await auth.use('jwt').generate(user)
 


### PR DESCRIPTION
Hello @MaximeMRF

I am very happy using your package, and while I was using it, I found things I would like it to already have, such as the ability to pass a name and abilities to the new refresh token with `authenticateWithRefreshToken` since I use the name as a JSON that stores data like the IP and user agent (due to the design of my application).

I made the modification and I hope you can pull it 😁.

````typescript
// this will authenticate the user using the refresh token
  // it will delete the old refresh token and generate a new one with the same abilities
  // You could pass a name for the new token as well
  const user = await auth.use('jwt').authenticateWithRefreshToken('optional_name')

